### PR TITLE
Update mail list from google groups to LF listserv

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Meetings will all be published on the [OSSF Community Calendar](https://calendar
 
 ### Communications
 
-We have a public email list available here: https://groups.google.com/g/wg-securing-critical-projects
+We have a public email list available here: https://lists.openssf.org/g/openssf-wg-securing-crit-prjs
 
 #### Notes and Agendas
 


### PR DESCRIPTION
For consideration... all the working groups have this mail list service setup on https://lists.openssf.org/. There's features of Google groups that are advantageous, but there's some consistency to using lists.openssf.org.