### PR TITLE
Update README to link to projects & key papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ To the best of our efforts, the goals of the working group are:
 2. Secure projects critical to the open-souce supply chain.
 3. Provide tools and novel solutions for critical open-source projects. 
 
+## Current WG projects
+
+* [criticality_score](https://github.com/ossf/criticality_score) - this attempts to estimate criticality using the algorithm described in ["Quantifying Criticality" by Rob Pike](https://github.com/ossf/criticality_score/blob/main/Quantifying_criticality_algorithm.pdf); you can see the [Hacker News Discussion](https://news.ycombinator.com/item?id=25381397). A known challenge is that it emphasizes activity, and some critical projects aren't active.
+* [Harvard research](https://www.coreinfrastructure.org/programs/census-program-ii/)
+* [package-feeds](https://github.com/ossf/package-feeds) / [package-analysis](https://github.com/ossf/package-analysis)
+* [allstar](https://github.com/ossf/allstar)
+
+## Related work to quantitatively identify critical projects
+
+* [*Vulnerabilities in the Core: Preliminary Report and Census II of Open Source Software*](https://www.coreinfrastructure.org/programs/census-program-ii/) by Frank Nagle, Jessica Wilkerson, James Dana, and Jennifer L. Hoffman, Linux Foundation & Harvard, February 2020.
+* [Open Source Software Projects Needing Security Investments](https://www.coreinfrastructure.org/wp-content/uploads/sites/6/2018/04/pub_ida_lf_cii_070915.pdf) by David A. Wheeler & Samir Khakimov, June 19, 2015
+* ["The Dark Reality of Open Source Through the Lens of Threat and Vulnerability Management" by Risksense](https://risksense.com/wp-content/uploads/2020/09/RiskSense-Spotlight-The-Dark-Reality-of-Open-Source.pdf), which identifies OSS with the most publicly-reported vulnerabilities reported as CVEs. Having more reported vulnerabilities does not mean that the software is necessarily more vulnerable; it often means that more people are looking for vulnerabilities & that there's a robust process for processing them. However, if so many people are searching for vulnerabilities in a product, that suggests it's an important (critical) project)
+* OSTIF's list of critical projects
+* [Core Infrastructure Initiative (CII) Open Source Software Census II Strategy](https://www.ida.org/research-and-publications/publications/all/c/co/core-infrastructure-initiative-cii-open-source-software-census-ii-strategy) by David A. Wheeler & Jason N. Dossett, October 2017
+* [Report on the 2020 FOSS Contributor Survey](https://www.linuxfoundation.org/blog/2020/12/download-the-report-on-the-2020-foss-contributor-survey/) by Frank Nagle, David A. Wheeler, Hila Lifshitz-Assaf, Haylee Ham, and Jennifer L. Hoffman
+
 
 ## Operations
 


### PR DESCRIPTION
Currently the README doesn't identify the WG projects.
This commit fixes this.