### PR TITLE
Remove useless TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This charter describes operations as an [OSSF Technical Initiative](https://gith
 The [Focus](#focus) section below describes what is in and out of scope,
 and [Governance](#governance) section describes how our operations are consistent with OSSF policies with links to more detailed documents.
 
-**Mission:** TODO
-
 ## Motivation
 
 <img align="right" src="https://imgs.xkcd.com/comics/dependency.png">


### PR DESCRIPTION
We've had a "mission: TODO" forever. Remove the useless TODO.
I think it's obvious from the rest of the text.
If someone wants to add content, great, but until then this
is only distracting.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>