### PR TITLE
docs: Add Allstar is now a part of the OpenSSF Scorecard project

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ For more details, see our [MVSR](/MVSR.md)
     * Lead: Caleb Brown
 * [package-analysis](https://github.com/ossf/package-analysis)
     * Lead: Caleb Brown
-* [Allstar](https://github.com/ossf/allstar)
-    * Lead: Jeff Mendoza
+
+## Former projects
+
+* [Allstar](https://github.com/ossf/allstar) is now a part of [OpenSSF Scorecard](https://scorecard.dev/)
 
 ### Role Definitions
 


### PR DESCRIPTION
ref: https://github.com/ossf/scorecard/issues/4073
closes https://github.com/ossf/wg-securing-critical-projects/issues/90
cc: @SecurityCRob @jeffmendoza 